### PR TITLE
MySQL 5.7 compatibility

### DIFF
--- a/Controller/Payment/Index.php
+++ b/Controller/Payment/Index.php
@@ -308,7 +308,7 @@ class Index extends Action
         if (!$dbConnection->isTableExists($tableName)) {
             $table = $dbConnection
                 ->newTable($tableName)
-                ->addColumn('id', Table::TYPE_SMALLINT, null, array('primary'=>true))
+                ->addColumn('id', Table::TYPE_SMALLINT, null, array('primary'=>true, 'nullable' => false))
                 ->addColumn('order_id', Table::TYPE_TEXT, 50)
                 ->addColumn('mg_order_id', Table::TYPE_TEXT, 50);
             return $dbConnection->createTable($table);


### PR DESCRIPTION
Fixes issue #11 by explicitly marking the id column as non-nullable, as required by newer MySQL versions.